### PR TITLE
Allow empty strings to represent nil values using user configs

### DIFF
--- a/ballerina-tests/parse-string-array-types-tests/tests/parse_string_to_array_test.bal
+++ b/ballerina-tests/parse-string-array-types-tests/tests/parse_string_to_array_test.bal
@@ -437,14 +437,12 @@ function testParseStringArrayAsExpectedTypeWithOutputHeaders() {
     ]);
 
     string[][]|csv:Error cv1baa_5 = csv:parseString(csvStringWithBooleanValues1, {outputWithHeaders: true, header: 2});
-    test:assertEquals(cv1baa_5, [
-        ["true", "false", "true", "false"],
-        ["true", "false", "true", "false"]
-    ]);
+    test:assertTrue(cv1baa_5 is csv:Error);
+    test:assertEquals((<csv:Error>cv1baa_5).message(), "Duplicate header found: 'true'");
 
-    string[][]|csv:Error cv1baa_6 = csv:parseString(csvStringWithBooleanValues1, {outputWithHeaders: false, header: 2});
+    string[][]|csv:Error cv1baa_6 = csv:parseString(csvStringWithBooleanValues8, {outputWithHeaders: false, header: 2});
     test:assertEquals(cv1baa_6, [
-        ["true", "false", "true", "false"]
+        ["true", "false", "true1", "false1"]
     ]);
 
     [string, string, string, string, string][]|csv:Error cv2baa_7 = csv:parseString(csvStringWithBooleanValues2, {outputWithHeaders: true});

--- a/ballerina-tests/parse-string-array-types-tests/tests/test_data_values.bal
+++ b/ballerina-tests/parse-string-array-types-tests/tests/test_data_values.bal
@@ -60,3 +60,9 @@ string csvStringWithBooleanValues6 = string `b2,b3
 string csvStringWithBooleanValues7 = string `b1,b2,b3,b4
 ${b1},${b2},(),${b4}
 `;
+
+string csvStringWithBooleanValues8 = string `b1,b2,b3,b4
+true,false,true1,false1 
+true,false, true1,false1
+true,false,true1,false1
+`;

--- a/ballerina-tests/type-compatible-tests/tests/csv_content_2.txt
+++ b/ballerina-tests/type-compatible-tests/tests/csv_content_2.txt
@@ -1,0 +1,4 @@
+a, b, c d, e
+"Hello World1", \"Hello World2\", Hello World3, 21
+"Hello World1", \"Hello World2\", Hello World3, 22
+"Hello World1", \"Hello World2\", Hello World3, 23

--- a/ballerina-tests/type-compatible-tests/tests/nill_type_test.bal
+++ b/ballerina-tests/type-compatible-tests/tests/nill_type_test.bal
@@ -1,0 +1,58 @@
+import ballerina/data.csv;
+import ballerina/test;
+
+type Book1 record {
+    ()|string name;
+    ()|string author;
+    ()|string year;
+};
+
+string csvString1 = string `name,author,year
+                            ,b,c
+                            a,,c
+                            a,b,`;
+
+@test:Config{}
+function testEmptyStringWithNilConfig() {
+    Book1[]|error books1 = csv:parseString(csvString1, {nilValue: ""});
+    test:assertEquals(books1, [
+        {name: null, author: "b", year: "c"},
+        {name: "a", author: null, year: "c"},
+        {name: "a", author: "b", year: null}
+    ]);
+
+    Book1[]|error books2 = csv:parseString(csvString1);
+    test:assertEquals(books2, [
+        {name: "", author: "b", year: "c"},
+        {name: "a", author: "", year: "c"},
+        {name: "a", author: "b", year: ""}
+    ]);
+
+    (boolean|()|string|int)[][]|error arrbooks1 = csv:parseString(csvString1, {nilValue: ""});
+    test:assertEquals(arrbooks1, [
+        [null, "b", "c"],
+        ["a", null, "c"],
+        ["a", "b", null]
+    ]);
+
+    (boolean|()|string|int)[][2]|error arrbooks2 = csv:parseString(csvString1, {nilValue: ""});
+    test:assertEquals(arrbooks2, [
+        [null, "b"],
+        ["a", null],
+        ["a", "b"]
+    ]);
+
+    (boolean|()|string|int)[][]|error arrbooks3 = csv:parseString(csvString1);
+    test:assertEquals(arrbooks3, [
+        ["", "b", "c"],
+        ["a", "", "c"],
+        ["a", "b", ""]
+    ]);
+
+    (boolean|()|string|int)[][2]|error arrbooks4 = csv:parseString(csvString1);
+    test:assertEquals(arrbooks4, [
+        ["", "b"],
+        ["a", ""],
+        ["a", "b"]
+    ]);
+}

--- a/ballerina-tests/type-compatible-tests/tests/parse_string_compatibality_test.bal
+++ b/ballerina-tests/type-compatible-tests/tests/parse_string_compatibality_test.bal
@@ -20,6 +20,7 @@ import ballerina/io;
 import ballerina/test;
 
 const string filepath = "tests/csv_content.txt";
+const string filepath2 = "tests/csv_content_2.txt";
 const string errorFilepath = "tests/csv_error_content.txt";
 
 @test:Config
@@ -215,6 +216,7 @@ function testSpaceBetweendData() {
 @test:Config
 function testParseBytes() returns error? {
     byte[] csvBytes = check io:fileReadBytes(filepath);
+    byte[] csvBytes2 = check io:fileReadBytes(filepath2);
 
     record{}[]|csv:Error rec = csv:parseBytes(csvBytes, {});
     test:assertEquals(rec, [
@@ -245,17 +247,17 @@ function testParseBytes() returns error? {
         ["Hello World", "\"Hello World\"", "Hello World", "2"]
     ]);
 
-    rec2 = csv:parseBytes(csvBytes, {outputWithHeaders: true, header: 1});
+    rec2 = csv:parseBytes(csvBytes2, {outputWithHeaders: true, header: 1});
     test:assertEquals(rec2, [
-        ["Hello World", "\"Hello World\"", "Hello World", "2"],
-        ["Hello World", "\"Hello World\"", "Hello World", "2"],
-        ["Hello World", "\"Hello World\"", "Hello World", "2"]
+        ["Hello World1", "\"Hello World2\"", "Hello World3", "21"],
+        ["Hello World1", "\"Hello World2\"", "Hello World3", "22"],
+        ["Hello World1", "\"Hello World2\"", "Hello World3", "23"]
     ]);
 
-    rec2 = csv:parseBytes(csvBytes, { header: 1});
+    rec2 = csv:parseBytes(csvBytes2, { header: 1});
     test:assertEquals(rec2, [
-        ["Hello World", "\"Hello World\"", "Hello World", "2"],
-        ["Hello World", "\"Hello World\"", "Hello World", "2"]
+        ["Hello World1", "\"Hello World2\"", "Hello World3", "22"],
+        ["Hello World1", "\"Hello World2\"", "Hello World3", "23"]
     ]);
 
     int[][]|csv:Error rec3 = csv:parseBytes(csvBytes, {});
@@ -270,6 +272,8 @@ function testParseBytes() returns error? {
 @test:Config
 function testParseStream() returns error? {
     stream<byte[], io:Error?> csvByteStream = check io:fileReadBlocksAsStream(filepath);
+    stream<byte[], io:Error?> csvByteStream2 = check io:fileReadBlocksAsStream(filepath2);
+
     record{}[]|csv:Error rec = csv:parseStream(csvByteStream, {});
     test:assertEquals(rec, [
         {"a":"Hello World","b":"\"Hello World\"","c d":"Hello World","e":2},
@@ -293,12 +297,11 @@ function testParseStream() returns error? {
         ["Hello World", "\"Hello World\"", "Hello World", "2"]
     ]);
 
-    csvByteStream = check io:fileReadBlocksAsStream(filepath);
-    rec2 = csv:parseStream(csvByteStream, {header: 1, outputWithHeaders: true});
+    rec2 = csv:parseStream(csvByteStream2, {header: 1, outputWithHeaders: true});
     test:assertEquals(rec2, [
-        ["Hello World", "\"Hello World\"", "Hello World", "2"],
-        ["Hello World", "\"Hello World\"", "Hello World", "2"],
-        ["Hello World", "\"Hello World\"", "Hello World", "2"]
+        ["Hello World1", "\"Hello World2\"", "Hello World3", "21"],
+        ["Hello World1", "\"Hello World2\"", "Hello World3", "22"],
+        ["Hello World1", "\"Hello World2\"", "Hello World3", "23"]
     ]);
 
     csvByteStream = check io:fileReadBlocksAsStream(filepath);
@@ -310,11 +313,11 @@ function testParseStream() returns error? {
         ["Hello World", "\"Hello World\"", "Hello World", "2"]
     ]);
 
-    csvByteStream = check io:fileReadBlocksAsStream(filepath);
+    csvByteStream = check io:fileReadBlocksAsStream(filepath2);
     rec2 = csv:parseStream(csvByteStream, {header: 1});
     test:assertEquals(rec2, [
-        ["Hello World", "\"Hello World\"", "Hello World", "2"],
-        ["Hello World", "\"Hello World\"", "Hello World", "2"]
+        ["Hello World1", "\"Hello World2\"", "Hello World3", "22"],
+        ["Hello World1", "\"Hello World2\"", "Hello World3", "23"]
     ]);
 
     csvByteStream = check io:fileReadBlocksAsStream(filepath);

--- a/ballerina-tests/user-config-tests/tests/test_data_values.bal
+++ b/ballerina-tests/user-config-tests/tests/test_data_values.bal
@@ -121,3 +121,28 @@ string csvStringData9 = string `
                         4@ string@ true@ 2.234@ ()@-3.21
 
                         5@ string@ true@ 2.234@ -3.21@ null`;                                             
+
+string csvStringData10 = string `
+                        hello, hello, (), 12, true, 12.34
+                        // comment
+                        
+                        a, b, c, d, e, f
+                        
+
+                        1, string1, true, 2.234, 2.234, ()
+                        2, string2, false, 0, 0, null
+                        3, string3, false, 1.23, 1.23, ()
+                        4, string4, true, -6.51, -6.52, ()
+                        5, string5, true, 3, 31, ()`;
+
+string csvStringData11 = string `
+                        a, b, c, d, e, f
+
+
+
+                        1, string1, true, 2.234, 2.234, ()
+                        2, string2, false, 0, 0, null
+                        3, string3, false, 1.23, 1.23, ()
+
+                        4, string4, true, -6.51, -6.52, ()
+                        5, string5, true, 3, 3, ()`;

--- a/native/src/main/java/io/ballerina/lib/data/csvdata/csv/CsvCreator.java
+++ b/native/src/main/java/io/ballerina/lib/data/csvdata/csv/CsvCreator.java
@@ -66,9 +66,9 @@ public final class CsvCreator {
         };
     }
 
-    static void convertAndUpdateCurrentJsonNode(CsvParser.StateMachine sm,
-                                                String value, Type type, CsvConfig config, Type exptype,
-                                                Field currentField) {
+    static void convertAndUpdateCurrentCsvNode(CsvParser.StateMachine sm,
+                                               String value, Type type, CsvConfig config, Type exptype,
+                                               Field currentField) {
         Object currentCsv = sm.currentCsvNode;
         Object nilValue = config.nilValue;
         if (sm.config.nilAsOptionalField && !type.isNilable()
@@ -91,6 +91,7 @@ public final class CsvCreator {
             case TypeTags.RECORD_TYPE_TAG:
                 ((BMap<BString, Object>) currentCsv).put(StringUtils.fromString(getHeaderValueForColumnIndex(sm)),
                         convertedValue);
+                sm.currentCsvNodeLength++;
                 return;
             case TypeTags.ARRAY_TAG:
                 ArrayType arrayType = (ArrayType) currentCsvNodeType;
@@ -99,9 +100,11 @@ public final class CsvCreator {
                     return;
                 }
                 ((BArray) currentCsv).add(sm.columnIndex, convertedValue);
+                sm.currentCsvNodeLength++;
                 return;
             case TypeTags.TUPLE_TAG:
                 ((BArray) currentCsv).add(sm.columnIndex, convertedValue);
+                sm.currentCsvNodeLength++;
                 return;
             default:
         }

--- a/native/src/main/java/io/ballerina/lib/data/csvdata/utils/DiagnosticErrorCode.java
+++ b/native/src/main/java/io/ballerina/lib/data/csvdata/utils/DiagnosticErrorCode.java
@@ -53,7 +53,9 @@ public enum DiagnosticErrorCode {
     SOURCE_CANNOT_CONVERT_INTO_EXP_TYPE("BDE_0026", "cannot.convert.into.exptype"),
     NO_CUSTOM_HEADER_PROVIDED("BDE_0027", "no.custom.header.provided"),
     HEADERS_WITH_VARYING_LENGTH_NOT_SUPPORTED("BDE_0027",
-            "headers.with.varying.length.not.supported");
+            "headers.with.varying.length.not.supported"),
+    HEADER_VALUE_CANNOT_BE_EMPTY("BDE_0028", "header.value.cannot.be.empty"),
+    DUPLICATE_HEADER("BDE_0029", "duplicate.header");
 
     String diagnosticId;
     String messageKey;

--- a/native/src/main/resources/csv_error.properties
+++ b/native/src/main/resources/csv_error.properties
@@ -104,3 +104,9 @@ error.no.custom.header.provided=\
 
 error.headers.with.varying.length.not.supported=\
   CSV data rows with varying headers are not yet supported
+
+error.header.value.cannot.be.empty=\
+  Header cannot be empty
+
+error.duplicate.header=\
+  Duplicate header found: ''{0}''


### PR DESCRIPTION
Allow empty strings to represent nil values using user configs
Fixes - https://github.com/ballerina-platform/ballerina-library/issues/6855