### PR TITLE
chore: downgrading the version to 0.8.2 to fix dependency resolution error in ftp package

### DIFF
--- a/ballerina-tests/constraint-validation-tests/Ballerina.toml
+++ b/ballerina-tests/constraint-validation-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "constraint_validation_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/constraint-validation-tests/Dependencies.toml
+++ b/ballerina-tests/constraint-validation-tests/Dependencies.toml
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "constraint_validation_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.csv"},
@@ -35,7 +35,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina-tests/csv-commons/Ballerina.toml
+++ b/ballerina-tests/csv-commons/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "csv_commons"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/csv-commons/Dependencies.toml
+++ b/ballerina-tests/csv-commons/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "csv_commons"
-version = "0.10.0"
+version = "0.8.2"
 modules = [
 	{org = "ballerina", packageName = "csv_commons", moduleName = "csv_commons"}
 ]

--- a/ballerina-tests/fail-safe-tests/Ballerina.toml
+++ b/ballerina-tests/fail-safe-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "fail_safe_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/fail-safe-tests/Dependencies.toml
+++ b/ballerina-tests/fail-safe-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -23,7 +23,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "fail_safe_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "data.csv"},
 	{org = "ballerina", name = "file"},

--- a/ballerina-tests/parse-list-types-tests/Ballerina.toml
+++ b/ballerina-tests/parse-list-types-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "parse_list_types_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/parse-list-types-tests/Dependencies.toml
+++ b/ballerina-tests/parse-list-types-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "csv_commons"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 modules = [
 	{org = "ballerina", packageName = "csv_commons", moduleName = "csv_commons"}
@@ -19,7 +19,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "parse_list_types_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "csv_commons"},
 	{org = "ballerina", name = "data.csv"},

--- a/ballerina-tests/parse-record-types-tests/Ballerina.toml
+++ b/ballerina-tests/parse-record-types-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "parse_record_types_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/parse-record-types-tests/Dependencies.toml
+++ b/ballerina-tests/parse-record-types-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "csv_commons"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 modules = [
 	{org = "ballerina", packageName = "csv_commons", moduleName = "csv_commons"}
@@ -19,7 +19,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "parse_record_types_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "csv_commons"},
 	{org = "ballerina", name = "data.csv"},

--- a/ballerina-tests/parse-string-array-types-tests/Ballerina.toml
+++ b/ballerina-tests/parse-string-array-types-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "parse_string_array_types_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/parse-string-array-types-tests/Dependencies.toml
+++ b/ballerina-tests/parse-string-array-types-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "csv_commons"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 modules = [
 	{org = "ballerina", packageName = "csv_commons", moduleName = "csv_commons"}
@@ -19,7 +19,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "parse_string_array_types_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "csv_commons"},
 	{org = "ballerina", name = "data.csv"},

--- a/ballerina-tests/parse-string-record-types-tests/Ballerina.toml
+++ b/ballerina-tests/parse-string-record-types-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "parse_string_record_types_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/parse-string-record-types-tests/Dependencies.toml
+++ b/ballerina-tests/parse-string-record-types-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "csv_commons"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 modules = [
 	{org = "ballerina", packageName = "csv_commons", moduleName = "csv_commons"}
@@ -19,7 +19,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "parse_string_record_types_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "csv_commons"},
 	{org = "ballerina", name = "data.csv"},

--- a/ballerina-tests/streaming-tests/Ballerina.toml
+++ b/ballerina-tests/streaming-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "streaming_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/streaming-tests/Dependencies.toml
+++ b/ballerina-tests/streaming-tests/Dependencies.toml
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -119,7 +119,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "streaming_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.csv"},

--- a/ballerina-tests/type-compatible-tests/Ballerina.toml
+++ b/ballerina-tests/type-compatible-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "type_compatible_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/type-compatible-tests/Dependencies.toml
+++ b/ballerina-tests/type-compatible-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "csv_commons"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 modules = [
 	{org = "ballerina", packageName = "csv_commons", moduleName = "csv_commons"}
@@ -19,7 +19,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -130,7 +130,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "type_compatible_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "csv_commons"},
 	{org = "ballerina", name = "data.csv"},

--- a/ballerina-tests/unicode-tests/Ballerina.toml
+++ b/ballerina-tests/unicode-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "unicode_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/unicode-tests/Dependencies.toml
+++ b/ballerina-tests/unicode-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -118,7 +118,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "unicode_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "data.csv"},
 	{org = "ballerina", name = "test"}

--- a/ballerina-tests/union-type-tests/Ballerina.toml
+++ b/ballerina-tests/union-type-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "union_type_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/union-type-tests/Dependencies.toml
+++ b/ballerina-tests/union-type-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "csv_commons"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 modules = [
 	{org = "ballerina", packageName = "csv_commons", moduleName = "csv_commons"}
@@ -19,7 +19,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -127,7 +127,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "union_type_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "csv_commons"},
 	{org = "ballerina", name = "data.csv"},

--- a/ballerina-tests/user-config-tests/Ballerina.toml
+++ b/ballerina-tests/user-config-tests/Ballerina.toml
@@ -1,13 +1,13 @@
 [package]
 org = "ballerina"
 name = "user_config_tests"
-version = "0.10.0"
+version = "0.8.2"
 
 [[dependency]]
 org = "ballerina"
 name = "csv_commons"
 repository = "local"
-version = "0.10.0"
+version = "0.8.2"
 
 [platform.java21]
 graalvmCompatible = true

--- a/ballerina-tests/user-config-tests/Dependencies.toml
+++ b/ballerina-tests/user-config-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "csv_commons"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 modules = [
 	{org = "ballerina", packageName = "csv_commons", moduleName = "csv_commons"}
@@ -19,7 +19,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -127,7 +127,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "user_config_tests"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "csv_commons"},
 	{org = "ballerina", name = "data.csv"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 authors = ["Ballerina"]
 keywords = ["csv"]
 repository = "https://github.com/ballerina-platform/module-ballerina-data.csv"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "data.csv-native"
-version = "0.10.0"
-path = "../native/build/libs/data.csv-native-0.10.0.jar"
+version = "0.8.2"
+path = "../native/build/libs/data.csv-native-0.8.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "data.csv-compiler-plugin"
 class = "io.ballerina.lib.data.csvdata.compiler.CsvDataCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/data.csv-compiler-plugin-0.10.0.jar"
+path = "../compiler-plugin/build/libs/data.csv-compiler-plugin-0.8.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "data.csv"
-version = "0.10.0"
+version = "0.8.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "log"}
@@ -61,7 +61,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=0.10.1-SNAPSHOT
+version=0.8.2-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 ballerinaTomlParserVersion=1.2.2
 
@@ -12,7 +12,7 @@ spotbugsVersion=6.0.18
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=4.0.4
 releasePluginVersion=2.8.0
-ballerinaGradlePluginVersion=2.3.0
+ballerinaGradlePluginVersion=2.3.1
 javaJsonPathVersion=2.9.0
 javaJsonSmartVersion=2.4.11
 javaAccessorsSmartVersion=2.4.7


### PR DESCRIPTION
## Purpose

$subject


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request downgrades the module version from 0.10.0 (or 0.10.1-SNAPSHOT) to 0.8.2 to resolve a dependency resolution error in the FTP package. The downgrade is applied consistently across all test modules and the main module configuration.

## Changes

- **Version downgrade across all modules**: All test modules (constraint-validation-tests, csv-commons, fail-safe-tests, parse-list-types-tests, parse-record-types-tests, parse-string-array-types-tests, parse-string-record-types-tests, streaming-tests, type-compatible-tests, unicode-tests, union-type-tests, and user-config-tests) have their package and dependency versions updated from 0.10.0 to 0.8.2.

- **Main module configuration updates**: 
  - `ballerina/Ballerina.toml`: Package version and native dependency path updated to 0.8.2
  - `ballerina/CompilerPlugin.toml`: Dependency path updated to reference 0.8.2-SNAPSHOT
  - `ballerina/Dependencies.toml`: Package version updated to 0.8.2; observe dependency updated to 1.5.1
  - `gradle.properties`: Version updated from 0.10.1-SNAPSHOT to 0.8.2-SNAPSHOT; Gradle plugin version updated to 2.3.1

- **Test module manifests**: All corresponding Dependencies.toml files for test modules updated to reflect the version changes for csv_commons and data.csv packages.

## Objective

This change addresses a dependency resolution error in the FTP package by reverting to a stable version that resolves compatibility issues with the current dependency tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->